### PR TITLE
Fix issue 17 in ngx-mat-period-picker

### DIFF
--- a/projects/ngx-mat-period-picker/src/lib/components/year-month-field.component.spec.ts
+++ b/projects/ngx-mat-period-picker/src/lib/components/year-month-field.component.spec.ts
@@ -159,13 +159,21 @@ describe('YearMonthFieldComponent', () => {
 
   describe('closePicker', () => {
     it('should dispose overlay when closing picker', () => {
-      const mockEvent = new MouseEvent('click');
-      component.openPicker(mockEvent);
+      // Create a mock overlay ref
+      const mockOverlayRef = {
+        dispose: jest.fn(),
+        attach: jest.fn(),
+        backdropClick: jest.fn().mockReturnValue({ subscribe: jest.fn() }),
+        keydownEvents: jest.fn().mockReturnValue({ subscribe: jest.fn() })
+      };
+      
+      // Manually set the overlay ref to simulate having an open overlay
+      component['overlayRef'] = mockOverlayRef as any;
 
-      const disposeSpy = jest.spyOn(component['overlayRef']!, 'dispose');
       component['closePicker']();
 
-      expect(disposeSpy).toHaveBeenCalled();
+      expect(mockOverlayRef.dispose).toHaveBeenCalled();
+      expect(component['overlayRef']).toBeNull();
     });
 
     it('should not dispose when no overlay exists', () => {

--- a/projects/ngx-mat-period-picker/src/lib/components/year-month-field.component.ts
+++ b/projects/ngx-mat-period-picker/src/lib/components/year-month-field.component.ts
@@ -166,12 +166,11 @@ export class YearMonthFieldComponent implements ControlValueAccessor {
       this.presentValueChange.emit(checked);
       this.onTouched();
 
-      // ONLY close when present is set to true
+      // Clear the value when present is selected, but don't close the popup
       if (checked) {
         // Clear the value when present is selected
         this.valueSignal.set(null);
         this.onChange(null);
-        this.closePicker();
       }
     });
 


### PR DESCRIPTION
Prevent period picker popup from closing when 'Present' checkbox is clicked to improve user experience.

Previously, clicking the 'Present' checkbox in the period picker would immediately close the popup due to an explicit `closePicker()` call. This change removes that call, allowing users to interact with the checkbox without unexpected closure. A related test was also updated to correctly mock the overlay reference.

---

[Open in Web](https://www.cursor.com/agents?id=bc-5ac54257-3439-442e-b888-e2362d8ae32d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5ac54257-3439-442e-b888-e2362d8ae32d)