### PR TITLE
fix(ci): restore demo deploy by publishing to gh-pages branch

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -16,9 +14,6 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout code
@@ -39,14 +34,9 @@ jobs:
       - name: Build demo app
         run: pnpm run build:demo
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './dist/demo-app'
-
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/demo-app/browser
+          keep_files: true


### PR DESCRIPTION
The demo deploy has been failing on every push to main since the pnpm
migration switched it to the Actions-native Pages flow (environment:
github-pages + configure-pages/deploy-pages). That flow requires the
repo's Pages source to be set to "GitHub Actions", but Pages is still
served from the gh-pages branch (as proven by pr-preview.yml, which
successfully pushes PR previews into subdirectories of that same
branch). The mismatch made every deploy job fail instantly with no
logs, before any step ran.

Revert to publishing the built demo straight to the gh-pages branch
root, keeping existing pr-preview/* subdirectories intact via
keep_files, so it matches how the site is actually served.